### PR TITLE
using optimised images in blogs

### DIFF
--- a/docs/_data/config.yml
+++ b/docs/_data/config.yml
@@ -26,3 +26,9 @@ items:
       - id: home
         label: Accueil
         href: https://www.terredesjeunes.org
+thumbor:
+  url: https://images.terredesjeunes.org
+  secret: unsafe
+  size: 500x
+  content_url: https://contenu.terredesjeunes.org
+  enable: true

--- a/docs/_includes/page_image.html
+++ b/docs/_includes/page_image.html
@@ -1,7 +1,15 @@
 {% if page_img %}
   <div class="image-gallery-wrapper clearfix">
-  {% for image in page_img %}
-    {% include image.html %}
-  {% endfor %}
+    {% for img in page_img %}
+      {% if site.data.config.thumbor.enable == true %}
+        {% assign thumbor_url = site.data.config.thumbor.url | append: '/' | append: site.data.config.thumbor.secret %}
+        {% assign size = site.data.config.thumbor.size %}
+        {% assign content_url = site.data.config.thumbor.content_url | append: '/' | append: img %}
+        {% assign image = thumbor_url | append: '/' | append: size | append: '/' | append: content_url %}
+      {% else %}
+        {% assign image = img %}
+      {% endif %}
+      {% include image.html %}
+    {% endfor %}
   </div>
 {% endif %}


### PR DESCRIPTION
[http://0.0.0.0:8253/jekyll_blogposts/2023/12/21/gestion_des_dechets_solides_a_serekeni_dans_la_commune_de_djiouera_au_burkina_faso.html](http://0.0.0.0:8253/jekyll_blogposts/2023/12/21/gestion_des_dechets_solides_a_serekeni_dans_la_commune_de_djiouera_au_burkina_faso.html) 

page using  blog layout   which is using website-content/docs/_includes/page_image.html  .


I think page_image.html is a common template to render a image.  page_image.html which might be used in some other layout also.

Note :- Now what ever the image media/XXXXXXX.jpg file we are passing to thumbor service https://images.terredesjeunes.org/unsafe/500x/contenu.terredesjeunes.org/   we get optimised image of size 500x.

that is because in config we are setting thumbor size parameter to 500x.

thumbor:
  url: https://images.terredesjeunes.org
  secret: unsafe
  size: 500x
  content_url: https://contenu.terredesjeunes.org
  enable: true


example :- https://images.terredesjeunes.org/unsafe/500x/contenu.terredesjeunes.org/media/img_20231219_112323_313.jpg 


Let me know if this is fine or we need to make size of a image modified based on its widget .